### PR TITLE
Add python script for easy of use

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: exhaustive
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python
+  - bowtie2
+  - bedtools
+  - click
+  - numpy

--- a/exhaustive.py
+++ b/exhaustive.py
@@ -5,65 +5,86 @@ import sys
 import click
 import subprocess
 from pathlib import Path
+from collections import OrderedDict
 
 ROOT_DIR = Path(__file__).parent.resolve()
 
+DEFAULTS = {"kmer": 150, "jump": 75, "threads": 8}
 
-@click.command(
-    help="Run exhaustive mapping of kmer substrings to a database.",
-    context_settings={"show_default": True},
-)
-@click.option(
-    "--base_label",
-    "-l",
-    help="base label for output files",
-    type=click.Path(path_type=Path),
-    default="exhaustive",
-)
-@click.option(
-    "--db_fna",
-    "-d",
-    help="the database in fasta format to map against",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
-    required=True,
-)
-@click.option(
-    "--db_bt2",
-    "-b",
-    help="the bowite2 index of the database to map against, it will be built if not provided",
-)
-@click.option(
-    "--files",
-    "-f",
-    help="the paths of genomes to generate substrings from",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
-)
-@click.option("--kmer", "-k", help="kmer length", type=int, default=150)
-@click.option("--jump", "-j", help="jump length", type=int, default=75)
-@click.option("--threads", "-t", help="number of threads to use", type=int, default=8)
-@click.option("--clean", "-c", help="remove temporary files", is_flag=True)
-def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
+
+shared_options = {
+    "db_fna": click.option(
+        "--db-fna",
+        "-d",
+        help="the database in fasta format (fna, fna.gz, or fna.xz) to map against",
+        required=True,
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    ),
+    "db_bt2": click.option(
+        "--db-bt2",
+        "-b",
+        help="the bowtie2 index of the database to map against",
+        required=True,
+        type=click.Path(path_type=Path),
+    ),
+    "files": click.option(
+        "--files",
+        "-f",
+        help="the paths of genomes to generate substrings from",
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    ),
+    "kmer": click.option(
+        "--kmer", "-k", help="kmer length", type=int, default=DEFAULTS["kmer"]
+    ),
+    "jump": click.option(
+        "--jump", "-j", help="jump length", type=int, default=DEFAULTS["jump"]
+    ),
+    "threads": click.option(
+        "--threads",
+        "-t",
+        help="number of threads to use",
+        type=int,
+        default=DEFAULTS["threads"],
+    ),
+}
+
+
+class CliOptions:
+    def __init__(self, options):
+        self.options = options
+        for name, option in options.items():
+            setattr(self, name, option)
+
+
+shared_opts = CliOptions(shared_options)
+
+
+def parse_base_label(base_label):
     base_label = Path(base_label)
     out_dir = base_label.parent.resolve()
     out_dir.mkdir(exist_ok=True, parents=True)
     base_label = base_label.name
+    return base_label, out_dir
 
-    tmp_dir = out_dir / f"{base_label}_{kmer}_{jump}"
-    tmp_dir.mkdir(exist_ok=True)
 
-    db_fna_stage = tmp_dir / "concat.fna"
+def _export_db(db_fna, db_fna_staged, build_index=False):
+
     if db_fna.suffix == ".gz":
-        db_fna_stage = db_fna.with_suffix("")
-        os.system(f"gunzip -c {db_fna}.gz > {db_fna_stage}")
+        db_fna_staged = db_fna.with_suffix("")
+        os.system(f"gunzip -c {db_fna}.gz > {db_fna_staged}")
     elif db_fna.suffix == ".xz":
-        db_fna_stage = db_fna.with_suffix("")
-        os.system(f"xzcat {db_fna} > {db_fna_stage}")
+        db_fna_staged = db_fna.with_suffix("")
+        os.system(f"xzcat {db_fna} > {db_fna_staged}")
+    elif db_fna.suffix == ".fna":
+        os.system(f"cp {db_fna} {db_fna_staged}")
     else:
-        os.system(f"cp {db_fna} {db_fna_stage}")
-    one_line_fna = db_fna_stage.with_suffix(".one-line.fna")
-    with open(db_fna_stage) as f_in, open(
-        db_fna_stage.with_suffix(".one-line.fna"), "w"
-    ) as f_out:
+        raise ValueError(f"Unsupported database format: {db_fna}")
+
+    one_line_fna = db_fna_staged.with_suffix(".one-line.fna")
+    with (
+        open(db_fna_staged) as f_in,
+        open(db_fna_staged.with_suffix(".one-line.fna"), "w") as f_out,
+    ):
         is_first = True
         for line in f_in:
             if line.startswith(">"):
@@ -75,17 +96,20 @@ def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
 
             else:
                 f_out.write(line.strip())
-    db_fna_stage = one_line_fna.rename(db_fna_stage)
-    if db_bt2 is None:
-        print("Building bowtie2 index for database")
-        db_bt2 = db_fna_stage.with_suffix("")
-        p_bt2 = subprocess.run(["bowtie2-build", str(db_fna_stage), str(db_bt2)])
+    db_fna_staged = one_line_fna.rename(db_fna_staged)
+    if build_index:
+        db_bt2 = db_fna_staged.parent / f"{db_fna_staged.stem}-bt2"
+        p_bt2 = subprocess.run(["bowtie2-build", str(db_fna_staged), str(db_bt2)])
+        if p_bt2.returncode:
+            raise RuntimeError("bowtie2-build failed")
     else:
-        print(f"Using existing bowtie2 index {db_bt2}")
+        db_bt2 = None
+    return db_fna_staged, db_bt2
 
-    ex_sam = tmp_dir / "exhaustive.sam"
-    if ex_sam.is_file():
-        print(f"Skipping {ex_sam} as it already exists")
+
+def _process_kmers(kmer, jump, files, task_id, task_count, threads, db_bt2, kmers_sam):
+    if kmers_sam.is_file():
+        print(f"Skipping {kmers_sam} as it already exists")
     else:
         genomes = []
         with open(files) as fp:
@@ -94,7 +118,14 @@ def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
                 genomes.append(file)
         p_cat = subprocess.Popen(["cat"] + genomes, stdout=subprocess.PIPE)
         p_kmer = subprocess.Popen(
-            ["python", str(ROOT_DIR / "kmer.py"), str(kmer), str(jump), "0", "1"],
+            [
+                "python",
+                str(ROOT_DIR / "kmer.py"),
+                str(kmer),
+                str(jump),
+                str(task_id),
+                str(task_count),
+            ],
             stdin=p_cat.stdout,
             stdout=subprocess.PIPE,
         )
@@ -129,38 +160,49 @@ def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
                 "--no-head",
                 "--no-unal",
                 "-S",
-                str(ex_sam),
+                str(kmers_sam),
             ],
             stdin=p_kmer.stdout,
         )
         print(" ".join(p_bt2.args))
         if p_bt2.returncode:
             raise RuntimeError("bowtie2 failed")
+    return kmers_sam
 
-    if os.stat(ex_sam).st_size == 0:
-        sys.exit(f"No kmer substrings mapped to database")
 
-    awk_tab = tmp_dir / "awk.aggregated"
-    with open(ex_sam) as f_in, open(awk_tab, "w") as f_out:
-        for line in f_in:
-            line = line.strip().split("\t")
-            f_out.write(
-                f"{line[2]}\t{line[3]}\t{int(line[3]) + len(line[9])}\t{line[0]}\t{line[9]}\n"
-            )
+def _process_regions(db_fna_staged, ex_out, output):
+    awk_tab = ex_out / "awk.aggregated"
+    for kmers_sam in ex_out.glob("*.sam"):
+        with open(kmers_sam) as f_in, open(awk_tab, "w") as f_out:
+            for line in f_in:
+                line = line.strip().split("\t")
+                f_out.write(
+                    f"{line[2]}\t{line[3]}\t{int(line[3]) + len(line[9])}\t{line[0]}\t{line[9]}\n"
+                )
 
     p_sort = subprocess.Popen(
-        ["sort", "--parallel", "8", "--buffer-size=100g", "-k1,1", "-k2,2n", awk_tab],
+        [
+            "sort",
+            "--parallel",
+            "8",
+            "--buffer-size=100g",
+            "-k1,1",
+            "-k2,2n",
+            awk_tab,
+        ],
         stdout=subprocess.PIPE,
     )
     sort_tab = awk_tab.with_suffix(".aggregated.sorted")
     with open(sort_tab, "w") as fp:
         p_dedup = subprocess.run(
-            ["python", str(ROOT_DIR / "deduplicate.py")], stdin=p_sort.stdout, stdout=fp
+            ["python", str(ROOT_DIR / "deduplicate.py")],
+            stdin=p_sort.stdout,
+            stdout=fp,
         )
     if p_dedup.returncode:
         raise RuntimeError("deduplicate.py failed")
     p_cat = subprocess.Popen(["cat", sort_tab], stdout=subprocess.PIPE)
-    merge_bed = tmp_dir / "exhaustive.bed"
+    merge_bed = ex_out / "exhaustive.bed"
     with open(merge_bed, "w") as fp:
         p_merge = subprocess.run(
             ["bedtools", "merge", "-i", "stdin", "-c", "5", "-o", "count"],
@@ -170,53 +212,54 @@ def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
     if p_merge.returncode:
         raise RuntimeError("bedtools merge failed")
 
-    contaminated = out_dir / f"{base_label}.contaminated.fna"
-    trim_bed = tmp_dir / "exhaustive.trimmed.bed"
+    trim_bed = ex_out / "exhaustive.trimmed.bed"
     p_trim = subprocess.run(
         [
             "python",
             str(ROOT_DIR / "trim-to-max-length.py"),
-            db_fna_stage,
+            db_fna_staged,
             merge_bed,
             trim_bed,
         ]
     )
     if p_trim.returncode:
         raise RuntimeError("trim-to-max-length.py failed")
-
     p_get = subprocess.run(
         [
             "bedtools",
             "getfasta",
             "-fi",
-            db_fna_stage,
+            db_fna_staged,
             "-bed",
             trim_bed,
             "-fo",
-            contaminated,
+            output,
         ]
     )
     if p_get.returncode:
         raise RuntimeError("bedtools getfasta failed")
 
-    db_fna_masked = out_dir / f"{base_label}.masked.fna"
+    return output
+
+
+def _filter_db(database_fasta, contaminated_fasta, output_fasta, output_bt2, threads):
 
     p_filter = subprocess.run(
         [
             "python",
             str(ROOT_DIR / "filter_fna.py"),
             "--database-fasta",
-            str(db_fna_stage),
+            str(database_fasta),
             "--output-fasta",
-            db_fna_masked,
+            output_fasta,
             "--contaminated-fasta",
-            contaminated,
+            contaminated_fasta,
         ]
     )
     if p_filter.returncode:
         raise RuntimeError("filter_fna.py failed")
 
-    idx_path = out_dir / f"{base_label}-bt2" / f"{base_label}-bt2"
+    idx_path = output_bt2
     idx_path.parent.mkdir(exist_ok=True)
     p_build = subprocess.run(
         [
@@ -225,20 +268,201 @@ def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
             "42",
             "--threads",
             str(threads),
-            str(db_fna_masked),
+            str(output_fasta),
             str(idx_path),
         ]
     )
     if p_build.returncode:
         raise RuntimeError("bowtie2-build failed")
 
+    return output_fasta, idx_path
+
+
+class OrderedGroup(click.Group):
+    def __init__(self, name=None, commands=None, **attrs):
+        super(OrderedGroup, self).__init__(name, commands, **attrs)
+        #: the registered subcommands by their exported names.
+        self.commands = commands or OrderedDict()
+
+    def list_commands(self, ctx):
+        return self.commands
+
+
+@click.group(cls=OrderedGroup)
+def cli():
+    pass
+
+
+@click.command(help="Export staged database fasta")
+@shared_opts.db_fna
+@click.option(
+    "--db-fna-staged",
+    "-s",
+    help="the staged database in fasta format",
+    required=True,
+    type=click.Path(exists=False, path_type=Path),
+)
+@click.option(
+    "--build_index",
+    "-b",
+    help="build bowtie2 index for staged database",
+    is_flag=True,
+)
+def export_db(db_fna, db_fna_staged, build_index):
+    _export_db(db_fna, db_fna_staged, build_index)
+
+
+@click.command(help="Mapping kmer substrings to database")
+@shared_opts.kmer
+@shared_opts.jump
+@shared_opts.files
+@shared_opts.threads
+@shared_opts.db_bt2
+@click.option(
+    "--ex_out",
+    "-o",
+    help="output directory for the sam files",
+    type=click.Path(path_type=Path),
+)
+@click.option(
+    "--task_id", "-i", help="task id for slurm array only", type=int, default=0
+)
+@click.option(
+    "--task_count", "-n", help="task count for slurm array only", type=int, default=1
+)
+def process_kmers(kmer, jump, files, task_id, task_count, threads, db_bt2, kmers_sam):
+    _process_kmers(kmer, jump, files, task_id, task_count, threads, db_bt2, kmers_sam)
+
+
+@click.command(help="Process regions")
+@click.option(
+    "--db-fna-staged",
+    "-d",
+    help="the staged database in fasta format",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--ex-out",
+    "-e",
+    help="directory containing the sam files and saving the output files",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--output",
+    "-o",
+    help="output fasta for the contaminated regions",
+    type=click.Path(path_type=Path),
+)
+def process_regions(db_fna_staged, ex_out, output):
+    _process_regions(db_fna_staged, ex_out, output)
+
+
+@click.command(
+    help="Mask database fasta with contaminated regions and build bowtie2 index"
+)
+@click.option(
+    "--database-fasta",
+    "-d",
+    help="the database in fasta format to filter",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--contaminated-fasta",
+    "-c",
+    help="contaminated fasta file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--output-fasta",
+    "-o",
+    help="output fasta file",
+    required=True,
+    type=click.Path(path_type=Path),
+)
+@click.option(
+    "--output-bt2",
+    "-m",
+    help="output bowtie2 index",
+    required=True,
+    type=click.Path(path_type=Path),
+)
+@shared_opts.threads
+def filter_db(database_fasta, contaminated_fasta, output_fasta, output_bt2, threads):
+    _filter_db(database_fasta, contaminated_fasta, output_fasta, output_bt2, threads)
+
+
+@click.command(
+    help="Run exhaustive cleaning (export-db -> process-kmers -> process-regions -> filter-db)",
+    context_settings={"show_default": True},
+)
+@click.option(
+    "--base_label",
+    "-l",
+    help="base label for output files",
+    type=click.Path(path_type=Path),
+    default="exhaustive",
+)
+@shared_opts.db_fna
+@click.option(
+    "--db-bt2",
+    "-b",
+    help="the bowtie2 index of the database to map against, it will be built if not provided",
+)
+@shared_opts.files
+@shared_opts.kmer
+@shared_opts.jump
+@shared_opts.threads
+@click.option("--clean", "-c", help="remove temporary files", is_flag=True)
+def submit(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
+    print("Starting exhaustive cleaning")
+    base_label, out_dir = parse_base_label(base_label)
+    ex_out = out_dir / f"{base_label}_{kmer}_{jump}"
+    ex_out.mkdir(exist_ok=True, parents=True)
+
+    db_fna_staged = ex_out / "concat.fna"
+    db_fna_staged, db_bt2_new = _export_db(db_fna, db_fna_staged, db_bt2 is None)
+    print(f"Staged database fasta: {db_fna_staged}")
+    if db_bt2:
+        print(f"Provided database index: {db_bt2}")
+    else:
+        print(f"Staged database index: {db_bt2_new}")
+        db_bt2 = db_bt2_new
+
+    kmers_sam = ex_out / "kmers.sam"
+    kmers_sam = _process_kmers(kmer, jump, files, 0, 1, threads, db_bt2, kmers_sam)
+    print(f"Kmer substrings mapped to database: {kmers_sam}")
+    if os.stat(kmers_sam).st_size == 0:
+        sys.exit(f"No kmer substrings mapped to database")
+
+    contam_fna = _process_regions(
+        db_fna_staged, ex_out, output=out_dir / f"{base_label}.contaminated.fna"
+    )
+    print(f"Contaminated regions: {contam_fna}")
+
+    db_fna_masked, db_bt2_masked = _filter_db(
+        db_fna_staged,
+        contam_fna,
+        out_dir / f"{base_label}.masked.fna",
+        out_dir / f"{base_label}-bt2" / f"{base_label}-bt2",
+        threads,
+    )
     print(f"Masked db fasta: {db_fna_masked}")
-    print(f"Masked db index: {idx_path}")
+    print(f"Masked db index: {db_bt2_masked}")
+
     if clean:
         print("Cleaning up temporary files")
-        os.system(f"rm -r {tmp_dir}")
+        os.system(f"rm -r {ex_out}")
     print("Exhaustive done.")
 
 
+cli.add_command(export_db)
+cli.add_command(process_kmers)
+cli.add_command(process_regions)
+cli.add_command(filter_db)
+cli.add_command(submit)
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/exhaustive.py
+++ b/exhaustive.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import click
+import subprocess
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent.resolve()
+
+
+@click.command(
+    help="Run exhaustive mapping of kmer substrings to a database.",
+    context_settings={"show_default": True},
+)
+@click.option(
+    "--base_label",
+    "-l",
+    help="base label for output files",
+    type=click.Path(path_type=Path),
+    default="exhaustive",
+)
+@click.option(
+    "--db_fna",
+    "-d",
+    help="the database in fasta format to map against",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+)
+@click.option(
+    "--db_bt2",
+    "-b",
+    help="the bowite2 index of the database to map against, it will be built if not provided",
+)
+@click.option(
+    "--files",
+    "-f",
+    help="the paths of genomes to generate substrings from",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--kmer", "-k", help="kmer length", type=int, default=150)
+@click.option("--jump", "-j", help="jump length", type=int, default=75)
+@click.option("--threads", "-t", help="number of threads to use", type=int, default=8)
+@click.option("--clean", "-c", help="remove temporary files", is_flag=True)
+def main(base_label, db_fna, db_bt2, files, kmer, jump, threads, clean):
+    base_label = Path(base_label)
+    out_dir = base_label.parent.resolve()
+    out_dir.mkdir(exist_ok=True, parents=True)
+    base_label = base_label.name
+
+    tmp_dir = out_dir / f"{base_label}_{kmer}_{jump}"
+    tmp_dir.mkdir(exist_ok=True)
+
+    db_fna_stage = tmp_dir / "concat.fna"
+    if db_fna.suffix == ".gz":
+        db_fna_stage = db_fna.with_suffix("")
+        os.system(f"gunzip -c {db_fna}.gz > {db_fna_stage}")
+    elif db_fna.suffix == ".xz":
+        db_fna_stage = db_fna.with_suffix("")
+        os.system(f"xzcat {db_fna} > {db_fna_stage}")
+    else:
+        os.system(f"cp {db_fna} {db_fna_stage}")
+    one_line_fna = db_fna_stage.with_suffix(".one-line.fna")
+    with open(db_fna_stage) as f_in, open(
+        db_fna_stage.with_suffix(".one-line.fna"), "w"
+    ) as f_out:
+        is_first = True
+        for line in f_in:
+            if line.startswith(">"):
+                if is_first:
+                    f_out.write(line)
+                    is_first = False
+                else:
+                    f_out.write(f"\n{line}")
+
+            else:
+                f_out.write(line.strip())
+    db_fna_stage = one_line_fna.rename(db_fna_stage)
+    if db_bt2 is None:
+        print("Building bowtie2 index for database")
+        db_bt2 = db_fna_stage.with_suffix("")
+        p_bt2 = subprocess.run(["bowtie2-build", str(db_fna_stage), str(db_bt2)])
+    else:
+        print(f"Using existing bowtie2 index {db_bt2}")
+
+    ex_sam = tmp_dir / "exhaustive.sam"
+    if ex_sam.is_file():
+        print(f"Skipping {ex_sam} as it already exists")
+    else:
+        genomes = []
+        with open(files) as fp:
+            for line in fp:
+                file = line.strip()
+                genomes.append(file)
+        p_cat = subprocess.Popen(["cat"] + genomes, stdout=subprocess.PIPE)
+        p_kmer = subprocess.Popen(
+            ["python", str(ROOT_DIR / "kmer.py"), str(kmer), str(jump), "0", "1"],
+            stdin=p_cat.stdout,
+            stdout=subprocess.PIPE,
+        )
+        if p_kmer.returncode:
+            raise RuntimeError("kmer.py failed")
+
+        print("Mapping kmer substrings to database")
+        p_bt2 = subprocess.run(
+            [
+                "bowtie2",
+                "-p",
+                str(threads),
+                "-x",
+                str(db_bt2),
+                "-f",
+                "-",
+                "--seed",
+                "42",
+                "--very-sensitive",
+                "-k",
+                "32",
+                "--np",
+                "1",
+                "--mp",
+                "1,1",
+                "--rdg",
+                "0,1",
+                "--rfg",
+                "0,1",
+                "--score-min",
+                "L,0,-0.05",
+                "--no-head",
+                "--no-unal",
+                "-S",
+                str(ex_sam),
+            ],
+            stdin=p_kmer.stdout,
+        )
+        print(" ".join(p_bt2.args))
+        if p_bt2.returncode:
+            raise RuntimeError("bowtie2 failed")
+
+    if os.stat(ex_sam).st_size == 0:
+        sys.exit(f"No kmer substrings mapped to database")
+
+    awk_tab = tmp_dir / "awk.aggregated"
+    with open(ex_sam) as f_in, open(awk_tab, "w") as f_out:
+        for line in f_in:
+            line = line.strip().split("\t")
+            f_out.write(
+                f"{line[2]}\t{line[3]}\t{int(line[3]) + len(line[9])}\t{line[0]}\t{line[9]}\n"
+            )
+
+    p_sort = subprocess.Popen(
+        ["sort", "--parallel", "8", "--buffer-size=100g", "-k1,1", "-k2,2n", awk_tab],
+        stdout=subprocess.PIPE,
+    )
+    sort_tab = awk_tab.with_suffix(".aggregated.sorted")
+    with open(sort_tab, "w") as fp:
+        p_dedup = subprocess.run(
+            ["python", str(ROOT_DIR / "deduplicate.py")], stdin=p_sort.stdout, stdout=fp
+        )
+    if p_dedup.returncode:
+        raise RuntimeError("deduplicate.py failed")
+    p_cat = subprocess.Popen(["cat", sort_tab], stdout=subprocess.PIPE)
+    merge_bed = tmp_dir / "exhaustive.bed"
+    with open(merge_bed, "w") as fp:
+        p_merge = subprocess.run(
+            ["bedtools", "merge", "-i", "stdin", "-c", "5", "-o", "count"],
+            stdin=p_cat.stdout,
+            stdout=fp,
+        )
+    if p_merge.returncode:
+        raise RuntimeError("bedtools merge failed")
+
+    contaminated = out_dir / f"{base_label}.contaminated.fna"
+    trim_bed = tmp_dir / "exhaustive.trimmed.bed"
+    p_trim = subprocess.run(
+        [
+            "python",
+            str(ROOT_DIR / "trim-to-max-length.py"),
+            db_fna_stage,
+            merge_bed,
+            trim_bed,
+        ]
+    )
+    if p_trim.returncode:
+        raise RuntimeError("trim-to-max-length.py failed")
+
+    p_get = subprocess.run(
+        [
+            "bedtools",
+            "getfasta",
+            "-fi",
+            db_fna_stage,
+            "-bed",
+            trim_bed,
+            "-fo",
+            contaminated,
+        ]
+    )
+    if p_get.returncode:
+        raise RuntimeError("bedtools getfasta failed")
+
+    db_fna_masked = out_dir / f"{base_label}.masked.fna"
+
+    p_filter = subprocess.run(
+        [
+            "python",
+            str(ROOT_DIR / "filter_fna.py"),
+            "--database-fasta",
+            str(db_fna_stage),
+            "--output-fasta",
+            db_fna_masked,
+            "--contaminated-fasta",
+            contaminated,
+        ]
+    )
+    if p_filter.returncode:
+        raise RuntimeError("filter_fna.py failed")
+
+    idx_path = out_dir / f"{base_label}-bt2" / f"{base_label}-bt2"
+    idx_path.parent.mkdir(exist_ok=True)
+    p_build = subprocess.run(
+        [
+            "bowtie2-build",
+            "--seed",
+            "42",
+            "--threads",
+            str(threads),
+            str(db_fna_masked),
+            str(idx_path),
+        ]
+    )
+    if p_build.returncode:
+        raise RuntimeError("bowtie2-build failed")
+
+    print(f"Masked db fasta: {db_fna_masked}")
+    print(f"Masked db index: {idx_path}")
+    if clean:
+        print("Cleaning up temporary files")
+        os.system(f"rm -r {tmp_dir}")
+    print("Exhaustive done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/filter_db.sbatch
+++ b/filter_db.sbatch
@@ -18,16 +18,23 @@ echo $TMPDIR
 if [[ -z ${FILE} ]]; then
     FILE=${BASE_LABEL}.fna
 fi
-
-python filter_fna.py \
-    --database-fasta ${DB_FNA_STAGED} \
-    --output-fasta ${DB_FNA_STAGED}.masked \
-    --contaminated-fasta ${FILE}
-
 mamba activate bowtie2
-mkdir -p ${BASE_LABEL}-bt2
-bowtie2-build --version
-bowtie2-build \
-    --seed 42 \
-    --threads 32 ${DB_FNA_STAGED}.masked \
-    ${BASE_LABEL}-bt2/${BASE_LABEL}-bt2
+
+python exhaustive.py filter-db \
+    --database-fasta ${DB_FNA_STAGED} \
+    --contaminated-fasta ${FILE} \
+    --output-fasta ${DB_FNA_STAGED}.masked \
+    --output-bt2 ${BASE_LABEL}-bt2/${BASE_LABEL}-bt2 \
+    --threads 32
+
+# python filter_fna.py \
+#     --database-fasta ${DB_FNA_STAGED} \
+#     --output-fasta ${DB_FNA_STAGED}.masked \
+#     --contaminated-fasta ${FILE}
+
+# mkdir -p ${BASE_LABEL}-bt2
+# bowtie2-build --version
+# bowtie2-build \
+#     --seed 42 \
+#     --threads 32 ${DB_FNA_STAGED}.masked \
+#     ${BASE_LABEL}-bt2/${BASE_LABEL}-bt2

--- a/filter_fna.py
+++ b/filter_fna.py
@@ -86,8 +86,7 @@ def main(database_fasta, output_fasta, contaminated_fasta):
                 seq = seq.strip()
 
                 assert id_.startswith('>')
-                id_ = id_[1:]
-
+                id_ = id_[1:].split(" ")[0]
                 if id_ in coordinates:
                     seq = mask(seq, coordinates[id_])
 

--- a/process.exhaustive.kmers.sbatch
+++ b/process.exhaustive.kmers.sbatch
@@ -37,22 +37,34 @@ fi
 mkdir -p ${EX_OUT}
 
 bt2_threads=$((${SLURM_CPUS_PER_TASK} - 2))
-for f in $(cat ${FILES})
-do
-    zcat ${f}
-done | \
-    python kmer.py ${K} ${J} ${SLURM_ARRAY_TASK_ID} ${SLURM_ARRAY_TASK_COUNT} | \
-    bowtie2 -p ${bt2_threads} \
-        -x ${DB_BT2} \
-        -f - \
-        --seed 42 \
-        --very-sensitive \
-        -k 32 \
-        --np 1 \
-        --mp "1,1" \
-        --rdg "0,1" \
-        --rfg "0,1" \
-        --score-min "L,0,-0.05" \
-        --no-head \
-        --no-unal | \
-            xz -1 -z -c > ${EX_OUT}/${SLURM_ARRAY_TASK_ID}.sam.xz
+
+python exhaustive.py process-kmers \
+    --kmer ${K} \
+    --jump ${J} \
+    --files ${FILES} \
+    --task-id ${SLURM_ARRAY_TASK_ID} \
+    --task-count ${SLURM_ARRAY_TASK_COUNT} \
+    --threads ${bt2_threads} \
+    --db-bt2 ${DB_BT2} \
+    --kmers-sam ${EX_OUT}/${SLURM_ARRAY_TASK_ID}.sam
+
+
+# for f in $(cat ${FILES})
+# do
+#     zcat ${f}
+# done | \
+#     python kmer.py ${K} ${J} ${SLURM_ARRAY_TASK_ID} ${SLURM_ARRAY_TASK_COUNT} | \
+#     bowtie2 -p ${bt2_threads} \
+#         -x ${DB_BT2} \
+#         -f - \
+#         --seed 42 \
+#         --very-sensitive \
+#         -k 32 \
+#         --np 1 \
+#         --mp "1,1" \
+#         --rdg "0,1" \
+#         --rfg "0,1" \
+#         --score-min "L,0,-0.05" \
+#         --no-head \
+#         --no-unal | \
+#             xz -1 -z -c > ${EX_OUT}/${SLURM_ARRAY_TASK_ID}.sam.xz

--- a/process.exhaustive.regions.sbatch
+++ b/process.exhaustive.regions.sbatch
@@ -19,40 +19,44 @@ set -x
 set -e
 set -o pipefail
 
+export LC_ALL=C
 
+python exhaustive.py process-regions \
+    --db-fna-staged ${DB_FNA_STAGED} \
+    --ex-out ${EX_OUT}   \
+    --output ${EX_OUT}/exhaustive.fna  
 #-----------------------------
 
 #Create bed path based on file input
-export LC_ALL=C
-xzcat -T 7 ${EX_OUT}/*.sam.xz | \
-    awk -F'\t' -v OFS='\t' '{sum = $4 + length($10); print $3, $4, sum, $1, $10}' | \
-    xz -1 -z -c -T 8 > ${EX_OUT}/awk.aggregated.xz
+# xzcat -T 7 ${EX_OUT}/*.sam.xz | \
+#     awk -F'\t' -v OFS='\t' '{sum = $4 + length($10); print $3, $4, sum, $1, $10}' | \
+#     xz -1 -z -c -T 8 > ${EX_OUT}/awk.aggregated.xz
 
-xzcat -T 4 ${EX_OUT}/awk.aggregated.xz | \
-    sort \
-        --parallel 8 \
-        --buffer-size=100g \
-        -k1,1 \
-        -k2,2n | \
-        python deduplicate.py | \
-        xz -1 -z -c -T 4 > ${EX_OUT}/awk.aggregated.sorted.xz
+# xzcat -T 4 ${EX_OUT}/awk.aggregated.xz | \
+#     sort \
+#         --parallel 8 \
+#         --buffer-size=100g \
+#         -k1,1 \
+#         -k2,2n | \
+#         python deduplicate.py | \
+#         xz -1 -z -c -T 4 > ${EX_OUT}/awk.aggregated.sorted.xz
 
-xzcat -T 15 ${EX_OUT}/awk.aggregated.sorted.xz | \
-    bedtools merge \
-        -i stdin \
-        -c 5 \
-        -o count > ${EX_OUT}/exhaustive.bed
-
-
-OUTPUT=${EX_OUT}/exhaustive.fna
+# xzcat -T 15 ${EX_OUT}/awk.aggregated.sorted.xz | \
+#     bedtools merge \
+#         -i stdin \
+#         -c 5 \
+#         -o count > ${EX_OUT}/exhaustive.bed
 
 
-python trim-to-max-length.py \
-    ${DB_FNA_STAGED} \
-    ${EX_OUT}/exhaustive.bed \
-    ${EX_OUT}/exhaustive.trimmed.bed
+# OUTPUT=${EX_OUT}/exhaustive.fna
 
-bedtools getfasta \
-    -fi ${DB_FNA_STAGED} \
-    -bed ${EX_OUT}/exhaustive.trimmed.bed \
-    -fo ${OUTPUT}
+
+# python trim-to-max-length.py \
+#     ${DB_FNA_STAGED} \
+#     ${EX_OUT}/exhaustive.bed \
+#     ${EX_OUT}/exhaustive.trimmed.bed
+
+# bedtools getfasta \
+#     -fi ${DB_FNA_STAGED} \
+#     -bed ${EX_OUT}/exhaustive.trimmed.bed \
+#     -fo ${OUTPUT}

--- a/stage.export_db.sbatch
+++ b/stage.export_db.sbatch
@@ -16,9 +16,13 @@ set -x
 set -e
 set -o pipefail
 
-if [[ "${DB_FNA}" == *".fna.xz" ]]; then
-    name=$(basename ${DB_FNA} .xz)
-    xzcat ${DB_FNA} > ${DB_FNA_STAGED}
-else
-    cp ${DB_FNA} ${DB_FNA_STAGED}
-fi
+python exhaustive.py export-db \
+    --db-fna ${DB_FNA} \
+    --db-fna-staged ${DB_FNA_STAGED}
+    
+# if [[ "${DB_FNA}" == *".fna.xz" ]]; then
+#     name=$(basename ${DB_FNA} .xz)
+#     xzcat ${DB_FNA} > ${DB_FNA_STAGED}
+# else
+#     cp ${DB_FNA} ${DB_FNA_STAGED}
+# fi

--- a/trim-to-max-length.py
+++ b/trim-to-max-length.py
@@ -21,4 +21,4 @@ with open(in_) as infp, open(out_, 'w') as outfp:
         if stop > lengths[gid]:
             stop = lengths[gid]
 
-        outfp.write("%s\t%s\t%d\t%s\n" % (gid, start, stop, noclue))
+        outfp.write("%s\t%s\t%d\n" % (gid, start, stop))


### PR DESCRIPTION
I have reviewed the sbatch scripts and merged them into a Python script (exhaustive.py) for ease of use. 
Additionally, I have addressed some bugs in filter_fna.py and trim-to-max-length.py.

## Bug fix
### filter_fna.py
Fixed a bug where providing a fasta file containing header descriptions would raise a KeyError from `coordinates[id_]`. 
This occurred, for example, when encountering headers like `>NC_060925.1 Homo sapiens isolate CHM13 chromosome 1, alternate assembly T2T-CHM13v2.0`.

### trim-to-max-length.py
Resolved a NameError issue where the variable `noclue` was referenced but not defined. As it appeared unnecessary, it has been removed from the script.


## Python script

### Help message
```
python exhaustive.py --help

Usage: exhaustive.py [OPTIONS]

  Run exhaustive mapping of kmer substrings to a database.

Options:
  -l, --base_label PATH  base label for output files  [default: exhaustive]
  -d, --db_fna FILE      the database in fasta format to map against
                         [required]
  -b, --db_bt2 TEXT      the bowite2 index of the database to map against, it
                         will be built if not provided
  -f, --files FILE       the paths of genomes to generate substrings from
  -k, --kmer INTEGER     kmer length  [default: 150]
  -j, --jump INTEGER     jump length  [default: 75]
  -t, --threads INTEGER  number of threads to use  [default: 8]
  -c, --clean            remove temporary files
  --help                 Show this message and exit.
```

### Demo

```
mamba env create -n exhaustive -f /path/to/environment.yml
mamba activate exhaustive
cd /path/to/work
# Download a human mitochondrion sequence to simulate as a contaminated database
wget -q -O mito.fna "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=GU170821.1&rettype=fasta"
bowtie2-build mito.fna mito-bt2

wget -q -O - https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/009/914/755/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz | 
gunzip -c > human.fna
realpath human.fna > genomes.txt

/path/to/exhaustive.py --base_label demo --db_fna  mito.fna --db_bt2 mito-bt2 --files genomes.txt
```

### Output files
```
.
├── demo_150_75 # temp directory
│   ├── awk.aggregated
│   ├── awk.aggregated.sorted
│   ├── concat.fna
│   ├── concat.fna.fai
│   ├── exhaustive.bed
│   ├── exhaustive.sam
│   └── exhaustive.trimmed.bed
├── demo-bt2 # masked bowtie2 index
│   ├── demo-bt2.1.bt2
│   ├── demo-bt2.2.bt2
│   ├── demo-bt2.3.bt2
│   ├── demo-bt2.4.bt2
│   ├── demo-bt2.rev.1.bt2
│   └── demo-bt2.rev.2.bt2
├── demo.contaminated.fna # contaminated regions
├── demo.masked.fna  # masked database

```


